### PR TITLE
always update deployments with latest image

### DIFF
--- a/apps/restart-operator-crds.yaml
+++ b/apps/restart-operator-crds.yaml
@@ -17,8 +17,5 @@ spec:
     server: https://kubernetes.default.svc
     namespace: servarr
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/apps/restart-operator-crds.yaml
+++ b/apps/restart-operator-crds.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/tylertitsworth/ai-cluster.git
-    targetRevision: restart-operator
+    targetRevision: main
     path: charts/restart-operator-crds
   destination:
     server: https://kubernetes.default.svc

--- a/apps/restart-operator-crds.yaml
+++ b/apps/restart-operator-crds.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: restart-operator-crds
+  namespace: argocd
+  labels:
+    stack: servarr
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/tylertitsworth/ai-cluster.git
+    targetRevision: restart-operator
+    path: charts/restart-operator-crds
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: servarr
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/restart-operator.yaml
+++ b/apps/restart-operator.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: restart-operator
+  namespace: argocd
+  labels:
+    stack: platform
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://archsyscall.github.io/restart-operator
+    chart: restart-operator
+    targetRevision: 0.1.1
+    helm:
+      releaseName: restart-operator
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: restart-operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/apps/restart-operator.yaml
+++ b/apps/restart-operator.yaml
@@ -19,9 +19,6 @@ spec:
     server: https://kubernetes.default.svc
     namespace: restart-operator
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apps/restart-operator.yaml
+++ b/apps/restart-operator.yaml
@@ -15,10 +15,19 @@ spec:
     targetRevision: 0.1.1
     helm:
       releaseName: restart-operator
+      valuesObject:
+        rbac:
+          create: false
+        operator:
+          leaderElection:
+            enabled: false
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
   destination:
     server: https://kubernetes.default.svc
     namespace: restart-operator
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true

--- a/charts/restart-operator-crds/Chart.yaml
+++ b/charts/restart-operator-crds/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: restart-operator-crds
+description: RestartSchedule custom resources driving cron-based workload restarts
+type: application
+version: 1.0.0
+appVersion: 0.1.1
+keywords:
+  - restart
+  - cron
+  - servarr
+sources:
+  - https://github.com/archsyscall/restart-operator

--- a/charts/restart-operator-crds/templates/rbac.yaml
+++ b/charts/restart-operator-crds/templates/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: restart-operator
+rules:
+  - apiGroups: ["restart-operator.k8s"]
+    resources: ["restartschedules"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["restart-operator.k8s"]
+    resources: ["restartschedules/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: restart-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: restart-operator
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.operator.serviceAccountName }}
+    namespace: {{ .Values.operator.namespace }}

--- a/charts/restart-operator-crds/templates/restartschedules.yaml
+++ b/charts/restart-operator-crds/templates/restartschedules.yaml
@@ -1,0 +1,17 @@
+{{- $ns := .Values.namespace -}}
+{{- range .Values.schedules }}
+---
+apiVersion: restart-operator.k8s/v1alpha1
+kind: RestartSchedule
+metadata:
+  name: {{ .name }}
+  namespace: {{ $ns }}
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/part-of: restart-operator
+spec:
+  schedule: "{{ required "each schedule entry needs a cron `schedule`" .schedule }}"
+  targetRef:
+    kind: {{ default "Deployment" .kind }}
+    name: {{ default .name .target }}
+{{- end }}

--- a/charts/restart-operator-crds/values.yaml
+++ b/charts/restart-operator-crds/values.yaml
@@ -1,6 +1,12 @@
 # Operator fires in UTC; times below are PT (UTC-7) converted to UTC.
 namespace: servarr
 
+# ServiceAccount the restart-operator runs as (RBAC is bound to it here because
+# the upstream chart ships its RBAC as Helm hooks that ArgoCD doesn't apply).
+operator:
+  namespace: restart-operator
+  serviceAccountName: restart-operator
+
 schedules:
   - name: qbittorrent-vpn
     schedule: "0 */3 * * *"

--- a/charts/restart-operator-crds/values.yaml
+++ b/charts/restart-operator-crds/values.yaml
@@ -1,0 +1,31 @@
+# Operator fires in UTC; times below are PT (UTC-7) converted to UTC.
+namespace: servarr
+
+schedules:
+  - name: qbittorrent-vpn
+    schedule: "0 */3 * * *"
+
+  - name: bazarr
+    schedule: "0 9 */3 * *"
+  - name: bookshelf
+    schedule: "15 9 */3 * *"
+  - name: fileflows
+    schedule: "30 9 */3 * *"
+  - name: flaresolverr
+    schedule: "45 9 */3 * *"
+  - name: kavita
+    schedule: "0 10 */3 * *"
+  - name: maintainerr
+    schedule: "15 10 */3 * *"
+  - name: overseerr
+    schedule: "30 10 */3 * *"
+  - name: profilarr
+    schedule: "45 10 */3 * *"
+  - name: prowlarr
+    schedule: "0 11 */3 * *"
+  - name: radarr
+    schedule: "15 11 */3 * *"
+  - name: sonarr
+    schedule: "30 11 */3 * *"
+  - name: tautulli
+    schedule: "45 11 */3 * *"

--- a/charts/restart-operator-crds/values.yaml
+++ b/charts/restart-operator-crds/values.yaml
@@ -1,4 +1,3 @@
-# Operator fires in UTC; times below are PT (UTC-7) converted to UTC.
 namespace: servarr
 
 # ServiceAccount the restart-operator runs as (RBAC is bound to it here because
@@ -10,28 +9,3 @@ operator:
 schedules:
   - name: qbittorrent-vpn
     schedule: "0 */3 * * *"
-
-  - name: bazarr
-    schedule: "0 9 */3 * *"
-  - name: bookshelf
-    schedule: "15 9 */3 * *"
-  - name: fileflows
-    schedule: "30 9 */3 * *"
-  - name: flaresolverr
-    schedule: "45 9 */3 * *"
-  - name: kavita
-    schedule: "0 10 */3 * *"
-  - name: maintainerr
-    schedule: "15 10 */3 * *"
-  - name: overseerr
-    schedule: "30 10 */3 * *"
-  - name: profilarr
-    schedule: "45 10 */3 * *"
-  - name: prowlarr
-    schedule: "0 11 */3 * *"
-  - name: radarr
-    schedule: "15 11 */3 * *"
-  - name: sonarr
-    schedule: "30 11 */3 * *"
-  - name: tautulli
-    schedule: "45 11 */3 * *"

--- a/charts/servarr/bookshelf/values.yaml
+++ b/charts/servarr/bookshelf/values.yaml
@@ -63,7 +63,7 @@ app-template:
                 identifier: main
                 port: http
       annotations:
-        tailscale.com/proxy-class: "control-plane"
+        tailscale.com/proxy-class: "pin-framework-desktop"
       tls:
         - hosts:
             - bookshelf

--- a/charts/servarr/fileflows/values.yaml
+++ b/charts/servarr/fileflows/values.yaml
@@ -55,7 +55,7 @@ app-template:
                 identifier: main
                 port: http
       annotations:
-        tailscale.com/proxy-class: "control-plane"
+        tailscale.com/proxy-class: "pin-framework-desktop"
       tls:
         - hosts:
             - fileflows

--- a/charts/servarr/maintainerr/values.yaml
+++ b/charts/servarr/maintainerr/values.yaml
@@ -67,7 +67,7 @@ app-template:
                 identifier: main
                 port: http
       annotations:
-        tailscale.com/proxy-class: "control-plane"
+        tailscale.com/proxy-class: "pin-framework-desktop"
       tls:
         - hosts:
             - maintainerr

--- a/charts/servarr/overseerr/values.yaml
+++ b/charts/servarr/overseerr/values.yaml
@@ -65,7 +65,7 @@ app-template:
                 identifier: main
                 port: http
       annotations:
-        tailscale.com/proxy-class: "control-plane"
+        tailscale.com/proxy-class: "pin-framework-desktop"
         tailscale.com/funnel: "true"
       tls:
         - hosts:

--- a/charts/servarr/radarr/values.yaml
+++ b/charts/servarr/radarr/values.yaml
@@ -64,7 +64,7 @@ app-template:
                 identifier: main
                 port: http
       annotations:
-        tailscale.com/proxy-class: "control-plane"
+        tailscale.com/proxy-class: "pin-framework-desktop"
       tls:
         - hosts:
             - radarr

--- a/manifests/image-updater-servarr.yaml
+++ b/manifests/image-updater-servarr.yaml
@@ -1,0 +1,120 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: servarr
+  namespace: argocd
+spec:
+  namespace: argocd
+  writeBackConfig:
+    method: argocd
+  # Each app follows the mutable tag it already runs and redeploys when that
+  # tag's digest changes. The tag on imageName is the constraint digest needs.
+  applicationRefs:
+    - namePattern: bazarr
+      images:
+        - alias: bazarr
+          imageName: lscr.io/linuxserver/bazarr:latest
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.bazarr.containers.main.image.repository
+              tag: app-template.controllers.bazarr.containers.main.image.tag
+    - namePattern: sonarr
+      images:
+        - alias: sonarr
+          imageName: lscr.io/linuxserver/sonarr:latest
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.sonarr.containers.main.image.repository
+              tag: app-template.controllers.sonarr.containers.main.image.tag
+    - namePattern: maintainerr
+      images:
+        - alias: maintainerr
+          imageName: ghcr.io/maintainerr/maintainerr:latest
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.maintainerr.containers.main.image.repository
+              tag: app-template.controllers.maintainerr.containers.main.image.tag
+    - namePattern: flaresolverr
+      images:
+        - alias: flaresolverr
+          imageName: ghcr.io/flaresolverr/flaresolverr:latest
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.flaresolverr.containers.main.image.repository
+              tag: app-template.controllers.flaresolverr.containers.main.image.tag
+    - namePattern: overseerr
+      images:
+        - alias: overseerr
+          imageName: ghcr.io/seerr-team/seerr:latest
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.overseerr.containers.main.image.repository
+              tag: app-template.controllers.overseerr.containers.main.image.tag
+    - namePattern: profilarr
+      images:
+        - alias: profilarr
+          imageName: index.docker.io/santiagosayshey/profilarr:beta
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.profilarr.containers.main.image.repository
+              tag: app-template.controllers.profilarr.containers.main.image.tag
+    - namePattern: bookshelf
+      images:
+        - alias: bookshelf
+          imageName: ghcr.io/pennydreadful/bookshelf:hardcover
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.bookshelf.containers.main.image.repository
+              tag: app-template.controllers.bookshelf.containers.main.image.tag
+    - namePattern: fileflows
+      images:
+        - alias: fileflows
+          imageName: index.docker.io/revenz/fileflows:latest
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.fileflows.containers.main.image.repository
+              tag: app-template.controllers.fileflows.containers.main.image.tag
+    - namePattern: kavita
+      images:
+        - alias: kavita
+          imageName: lscr.io/linuxserver/kavita:latest
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.kavita.containers.main.image.repository
+              tag: app-template.controllers.kavita.containers.main.image.tag
+    - namePattern: prowlarr
+      images:
+        - alias: prowlarr
+          imageName: lscr.io/linuxserver/prowlarr:latest
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.prowlarr.containers.main.image.repository
+              tag: app-template.controllers.prowlarr.containers.main.image.tag
+    - namePattern: radarr
+      images:
+        - alias: radarr
+          imageName: lscr.io/linuxserver/radarr:latest
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.radarr.containers.main.image.repository
+              tag: app-template.controllers.radarr.containers.main.image.tag
+    - namePattern: tautulli
+      images:
+        - alias: tautulli
+          imageName: lscr.io/linuxserver/tautulli:latest
+          commonUpdateSettings: {updateStrategy: digest, forceUpdate: false}
+          manifestTargets:
+            helm:
+              name: app-template.controllers.tautulli.containers.main.image.repository
+              tag: app-template.controllers.tautulli.containers.main.image.tag


### PR DESCRIPTION
Wires up argocd-image-updater to auto-roll the servarr apps whenever their image gets a new build. Each app follows the tag it already runs (latest, or beta/hardcover for the odd ones) with the digest strategy, so a new push to that tag triggers a redeploy. plex already had its own updater so it's left alone, and qbittorrent stays on the restart-operator since that's a timed restart, not an image bump.

Had to bump image-updater 1.0.2 -> 1.2.2 for this — the digest strategy in the ImageUpdater CR doesn't work on 1.0.x. Also still includes the restart-operator bits (qbittorrent every 3h, servarr every 72h staggered) from before.