### PR TITLE
Run container CI on PRs that touch build paths

### DIFF
--- a/.github/workflows/jetson-exporter-build.yaml
+++ b/.github/workflows/jetson-exporter-build.yaml
@@ -8,6 +8,11 @@ on:
       - 'jetson-exporter/Dockerfile'
       - 'jetson-exporter/exporter.py'
       - 'jetson-exporter/requirements.txt'
+  pull_request:
+    paths:
+      - 'jetson-exporter/Dockerfile'
+      - 'jetson-exporter/exporter.py'
+      - 'jetson-exporter/requirements.txt'
 
 jobs:
   build:
@@ -33,7 +38,7 @@ jobs:
         with:
           context: jetson-exporter
           file: ./jetson-exporter/Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64

--- a/.github/workflows/npu-device-plugin-build.yaml
+++ b/.github/workflows/npu-device-plugin-build.yaml
@@ -8,6 +8,11 @@ on:
       - 'npu-device-plugin/*.go'
       - 'npu-device-plugin/Dockerfile'
       - 'npu-device-plugin/go.*'
+  pull_request:
+    paths:
+      - 'npu-device-plugin/*.go'
+      - 'npu-device-plugin/Dockerfile'
+      - 'npu-device-plugin/go.*'
 
 jobs:
   build:
@@ -33,7 +38,7 @@ jobs:
         with:
           context: .
           file: ./npu-device-plugin/Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/arm64


### PR DESCRIPTION
## Summary
- Add a `pull_request` trigger to jetson-exporter and npu-device-plugin build workflows, matching each one's existing `push` `paths` filter
- Skip the registry push (`push: false`) on PR runs so only pushes to `main` publish images; PR runs just validate the build

## Test plan
- [ ] Open a PR touching `jetson-exporter/*` and confirm the build workflow runs without pushing an image
- [ ] Open a PR touching `npu-device-plugin/*` and confirm the same
- [ ] Confirm push-to-main builds still push images as before