### PR TITLE
Add opencode and vllm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ npu-device-plugin/pkg/
 files/
 AGENTS.md
 CLAUDE.md
+*.tgz

--- a/apps/ai/opencode.yaml
+++ b/apps/ai/opencode.yaml
@@ -1,0 +1,40 @@
+# ArgoCD Application — OpenCode headless server
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opencode
+  namespace: argocd
+  labels:
+    stack: ai
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/tylertitsworth/ai-cluster.git
+      targetRevision: opencode-vllm
+      path: charts/opencode
+      helm:
+        valueFiles:
+          - $values/apps/ai/values/opencode.yaml
+    - repoURL: https://github.com/tylertitsworth/ai-cluster.git
+      targetRevision: opencode-vllm
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: opencode
+  syncPolicy:
+    automated:
+      enabled: false
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      name: opencode
+      jqPathExpressions:
+        - .metadata.annotations["deployment.kubernetes.io/revision"]
+        - .metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]
+        - .spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]

--- a/apps/ai/values/ollama.yaml
+++ b/apps/ai/values/ollama.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ollama
 image:
   repository: ollama/ollama
   # Pinned latest versioned ROCm image tag
-  tag: 0.21.2-rocm
+  tag: 0.32.5-rocm
   pullPolicy: Always
 
 ollama:
@@ -17,18 +17,9 @@ ollama:
     pull:
       - qwen3.6:35b
       - gemma4:31b
-    create:
-      - name: qwen3.6-35b-full
-        template: |
-          FROM qwen3.6:35b
-          PARAMETER num_ctx 262144
-      - name: gemma-4-31b-full
-        template: |
-          FROM gemma4:31b
-          PARAMETER num_ctx 262144
     run:
-      # - genna4-31b-full
-      - qwen3.6-35b-full
+      - gemma4:31b
+      # - qwen3.6:35b
     clean: true
 
 extraEnv:

--- a/apps/ai/values/opencode.yaml
+++ b/apps/ai/values/opencode.yaml
@@ -1,0 +1,7 @@
+# Override values for the opencode chart (charts/opencode).
+# Full structure: https://github.com/bjw-s-labs/helm-charts/tree/main/charts/app-template
+
+app-template:
+  controllers:
+    main:
+      nameOverride: opencode

--- a/apps/ai/values/vllm.yaml
+++ b/apps/ai/values/vllm.yaml
@@ -1,0 +1,7 @@
+# Override values for the vllm chart (charts/vllm).
+# Full structure: https://github.com/bjw-s-labs/helm-charts/tree/main/charts/app-template
+
+app-template:
+  controllers:
+    vllm:
+      nameOverride: vllm

--- a/apps/ai/vllm.yaml
+++ b/apps/ai/vllm.yaml
@@ -1,0 +1,41 @@
+# vLLM inference server
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vllm
+  namespace: argocd
+  labels:
+    stack: ai
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/tylertitsworth/ai-cluster.git
+      targetRevision: opencode-vllm
+      path: charts/vllm
+      helm:
+        valueFiles:
+          - $values/apps/ai/values/vllm.yaml
+    - repoURL: https://github.com/tylertitsworth/ai-cluster.git
+      targetRevision: opencode-vllm
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ollama
+  syncPolicy:
+    automated:
+      enabled: false
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+  # Server-set annotations that are not part of the desired state.
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      name: vllm
+      jqPathExpressions:
+        - .metadata.annotations["deployment.kubernetes.io/revision"]
+        - .metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]
+        - .spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"]

--- a/apps/platform/kubernetes-mcp-rbac.yaml
+++ b/apps/platform/kubernetes-mcp-rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kubernetes-mcp-rbac
+  namespace: argocd
+  labels:
+    stack: platform
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/tylertitsworth/ai-cluster.git
+    targetRevision: main
+    path: charts/kubernetes-mcp-rbac
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kubernetes-mcp
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/charts/kubernetes-mcp-rbac/Chart.yaml
+++ b/charts/kubernetes-mcp-rbac/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: kubernetes-mcp-rbac
+description: ArgoCD RBAC for the kubernetes-mcp-server-rw ServiceAccount
+type: application
+version: 1.0.0

--- a/charts/kubernetes-mcp-rbac/templates/rbac.yaml
+++ b/charts/kubernetes-mcp-rbac/templates/rbac.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-mcp-server-rw-argocd-view
+  labels:
+    app: kubernetes-mcp-server-rw
+    stack: platform
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - appprojects
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-mcp-server-rw-argocd-view
+  labels:
+    app: kubernetes-mcp-server-rw
+    stack: platform
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-mcp-server-rw-argocd-view
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Values.serviceAccount.namespace }}

--- a/charts/kubernetes-mcp-rbac/values.yaml
+++ b/charts/kubernetes-mcp-rbac/values.yaml
@@ -1,0 +1,3 @@
+serviceAccount:
+  name: kubernetes-mcp-server-rw
+  namespace: kubernetes-mcp

--- a/charts/opencode/Chart.lock
+++ b/charts/opencode/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: app-template
+  repository: https://bjw-s-labs.github.io/helm-charts/
+  version: 3.7.3
+digest: sha256:c519bb3ff6aa1460d0ac8ae623fb9656ffce840536696aa934c390ac1703eb21
+generated: "2026-08-06T22:23:10.997910903Z"

--- a/charts/opencode/Chart.yaml
+++ b/charts/opencode/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: opencode
+description: OpenCode headless server
+type: application
+version: 0.1.0
+appVersion: "1.18.15"
+dependencies:
+  - name: app-template
+    version: 3.x.x
+    repository: https://bjw-s-labs.github.io/helm-charts/

--- a/charts/opencode/templates/configmap.yaml
+++ b/charts/opencode/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opencode-config
+  namespace: {{ .Release.Namespace }}
+data:
+{{ .Values.opencodeConfig | toYaml | indent 2 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opencode-ui-nginx
+  namespace: {{ .Release.Namespace }}
+data:
+{{ .Values.uiNginxConf | toYaml | indent 2 }}

--- a/charts/opencode/values.yaml
+++ b/charts/opencode/values.yaml
@@ -1,0 +1,361 @@
+# OpenCode headless server — access via Tailscale from browser / phone.
+# Image: sprisa/opencode (Ubuntu, unprivileged uid 1000, tini, env-driven serve config).
+# Full app-template schema: https://github.com/bjw-s-labs/helm-charts/tree/main/charts/app-template
+app-template:
+  controllers:
+    main:
+      type: deployment
+      replicas: 1
+      strategy: Recreate
+
+      pod:
+        # Pin to the node with the workspace PVC (mirrors the original nodeName)
+        nodeSelector:
+          kubernetes.io/hostname: framework-desktop
+        securityContext:
+          fsGroup: 1000
+
+      initContainers:
+        init:
+          image:
+            repository: alpine/git
+            tag: latest
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              mkdir -p /home/opencode/workspace /home/opencode/.local/share/opencode
+              rm -rf /home/opencode/workspace/lost+found /home/opencode/.local/share/opencode/lost+found
+              if [ ! -d /home/opencode/workspace/.git ]; then
+                echo "Cloning ai-cluster into /home/opencode/workspace..."
+                git clone --depth 1 https://github.com/tylertitsworth/ai-cluster.git /home/opencode/workspace
+              else
+                echo "Workspace already seeded, skipping clone."
+              fi
+              cat > /home/opencode/.local/share/opencode/.gitconfig <<'EOF'
+              [user]
+                      name = tylertitsworth
+                      email = tylertitsworth@users.noreply.github.com
+              [credential]
+                      helper = !f() { echo username=tylertitsworth; echo password=$GITHUB_TOKEN; }; f
+              [safe]
+                      directory = /home/opencode/workspace
+              EOF
+              chown -R 1000:1000 /home/opencode/workspace /home/opencode/.local/share/opencode
+          env:
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: opencode-github
+                  key: token
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+
+      containers:
+        opencode:
+          image:
+            repository: sprisa/opencode
+            tag: 1.18.15
+            pullPolicy: IfNotPresent
+          ports:
+            - containerPort: 4096
+              name: http
+              protocol: TCP
+          env:
+            - name: OPENCODE_SERVER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: opencode-secret
+                  key: password
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: opencode-github
+                  key: token
+            - name: GIT_CONFIG_GLOBAL
+              value: /home/opencode/.local/share/opencode/.gitconfig
+            - name: OPENCODE_PORT
+              value: "4096"
+          probes:
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                exec:
+                  command:
+                    - sh
+                    - -c
+                    - |
+                      AUTH="opencode:$OPENCODE_SERVER_PASSWORD"
+                      curl -fsS -o /dev/null -H "Authorization: Basic $(printf '%s' "$AUTH" | base64)" http://127.0.0.1:4096/global/health
+                initialDelaySeconds: 10
+                periodSeconds: 10
+            liveness:
+              enabled: true
+              custom: true
+              spec:
+                exec:
+                  command:
+                    - sh
+                    - -c
+                    - |
+                      AUTH="opencode:$OPENCODE_SERVER_PASSWORD"
+                      curl -fsS -o /dev/null -H "Authorization: Basic $(printf '%s' "$AUTH" | base64)" http://127.0.0.1:4096/global/health
+                initialDelaySeconds: 15
+                periodSeconds: 20
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+
+        ui:
+          image:
+            repository: nginx
+            tag: alpine
+            pullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: http-ui
+              protocol: TCP
+          probes:
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                exec:
+                  command:
+                    - sh
+                    - -c
+                    - |
+                      wget -q -O /dev/null http://127.0.0.1/assets/index-DkiM3pJJ.js || exit 1
+                initialDelaySeconds: 5
+                periodSeconds: 10
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+
+  service:
+    main:
+      controller: main
+      type: ClusterIP
+      ports:
+        http:
+          enabled: true
+          port: 4096
+          targetPort: 4096
+        ui:
+          enabled: true
+          port: 80
+          targetPort: 80
+
+  ingress:
+    main:
+      enabled: true
+      className: tailscale
+      annotations:
+        tailscale.com/proxy-class: pin-framework-desktop
+      hosts:
+        - host: opencode
+          paths:
+            - path: /
+              pathType: Prefix
+              service:
+                identifier: main
+                port: ui
+      tls:
+        - hosts:
+            - opencode
+
+  persistence:
+    workspace:
+      enabled: true
+      type: persistentVolumeClaim
+      accessMode: ReadWriteOnce
+      storageClass: longhorn
+      size: 20Gi
+      advancedMounts:
+        main:
+          init:
+            - path: /home/opencode/workspace
+          opencode:
+            - path: /home/opencode/workspace
+            - path: /workspace
+          ui:
+            - path: /workspace
+              readOnly: true
+    data:
+      enabled: true
+      type: persistentVolumeClaim
+      accessMode: ReadWriteOnce
+      storageClass: longhorn
+      size: 5Gi
+      advancedMounts:
+        main:
+          init:
+            - path: /home/opencode/.local/share/opencode
+          opencode:
+            - path: /home/opencode/.local/share/opencode
+    config:
+      enabled: true
+      type: configMap
+      name: opencode-config
+      advancedMounts:
+        main:
+          opencode:
+            - path: /home/opencode/.config/opencode/opencode.json
+              subPath: opencode.json
+              readOnly: true
+            - path: /home/opencode/.config/opencode/AGENTS.md
+              subPath: AGENTS.md
+              readOnly: true
+    ui-nginx-conf:
+      enabled: true
+      type: configMap
+      name: opencode-ui-nginx
+      advancedMounts:
+        main:
+          ui:
+            - path: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+
+# opencode config rendered to the opencode-config ConfigMap.
+# Keys are validated against https://opencode.ai/config.json — unknown keys (e.g.
+# `session.*`) break validation and prevent ArgoCD from applying the ConfigMap.
+opencodeConfig:
+  opencode.json: |
+    {
+      "$schema": "https://opencode.ai/config.json",
+      "permission": "allow",
+      "plugin": [
+        "@dietrichgebert/ponytail",
+        "context-mode",
+        "superpowers-mcp"
+      ],
+      "model": "vllm/qwen3.6-35b-a3b-awq",
+      "mcp": {
+        "kubernetes-ro": {
+          "type": "remote",
+          "url": "http://kubernetes-mcp-server.kubernetes-mcp.svc.cluster.local:8080/mcp",
+          "enabled": true
+        },
+        "kubernetes-rw": {
+          "type": "remote",
+          "url": "http://kubernetes-mcp-server-rw.kubernetes-mcp.svc.cluster.local:8080/mcp",
+          "enabled": true
+        },
+        "github": {
+          "type": "remote",
+          "url": "https://api.githubcopilot.com/mcp/",
+          "enabled": true,
+          "oauth": false,
+          "headers": {
+            "Authorization": "Bearer {env:GITHUB_TOKEN}"
+          }
+        }
+      },
+      "provider": {
+        "vllm": {
+          "npm": "@ai-sdk/openai-compatible",
+          "name": "vLLM",
+          "options": {
+            "baseURL": "http://vllm.ollama.svc.cluster.local:8000/v1"
+          },
+          "models": {
+            "qwen3.6-35b-a3b-awq": {
+              "name": "Qwen3.6-35B-A3B-AWQ-4bit",
+              "id": "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit"
+            }
+          }
+        }
+      }
+    }
+  AGENTS.md: |
+    # OpenCode Server — Session Context
+
+    You are running in the opencode headless server pod (namespace `opencode`, node
+    `framework-desktop`). Working directory is `/home/opencode/workspace`, a clone of
+    ai-cluster. All state persists under `/home/opencode` (config, sessions DB, logs).
+
+    ## Tool Access
+    kubectl is NOT available in this container. Use the Kubernetes MCP tools for all
+    cluster operations:
+    - `kubernetes-ro_*` for read-only queries (list, get, events, etc.)
+    - `kubernetes-rw_*` for mutations (create, update, delete, exec)
+    - `list_mcp_resources` to discover available tool endpoints
+    Do NOT `kubernetes-rw_pods_exec` into the opencode pod — you are already running
+    inside it, so just use bash directly for local inspection.
+
+    ## Config Validation
+    opencode.json keys are validated against https://opencode.ai/config.json. Adding
+    unknown keys (e.g. `session.*`) breaks validation and prevents ArgoCD from applying
+    the ConfigMap. Validate config changes before deploying.
+
+    ## Git
+    The git credential helper lives in `/home/opencode/.local/share/opencode/.gitconfig`.
+    If auth fails, push using the remote URL form
+    `https://tylertitsworth:<token>@github.com/...` where the token is the GITHUB_TOKEN
+    value. The opencode-vllm branch is deployed by ArgoCD (app `opencode`, path
+    `charts/opencode`); sync manually via `kubectl argocd app sync opencode -n argocd`.
+
+    ## Deployment
+    The deployment is a helm chart at `charts/opencode` (values in
+    `charts/opencode/values.yaml`, overrides in `apps/ai/values/opencode.yaml`) on
+    branch `opencode-vllm` (ArgoCD tracks this branch). Config, limits, and AGENTS.md
+    are all defined in the chart. After pushing, the user syncs ArgoCD manually.
+
+    ## Memory Constraints
+    This pod has a 4Gi memory limit. A Grafana-observed spike reached 2.74GB during a
+    heavy session, so DO NOT lower the limit below 4Gi (a 3Gi limit was tried and left
+    only ~260MB headroom against observed usage). Keep memory requests/limits as-is unless
+    you have new data. The following operations can trigger OOM kills and must be AVOIDED:
+    - **Heap snapshots**: Do NOT attempt to generate heap snapshots (Ctrl+P → heap snapshot
+      or `OPENCODE_AUTO_HEAP_SNAPSHOT=1`). This dumps the entire V8 heap to disk and can
+      spike RSS by 1-2GB. If heap debugging is needed, advise the user to run opencode
+      locally or on a separate pod with higher limits.
+    - **Dumping large files**: Avoid reading entire large files (>1MB) into the agent context.
+      Use grep/glob/head for content exploration instead of full file reads.
+    - **Long-running session accumulations**: If the conversation or session tree is extremely
+      long, suggest compacting or starting a new session to release accumulated context.
+    - **npm install / large subprocesses**: Avoid running `npm install` inside the agent.
+      If package changes are needed, have the user do it outside this pod.
+
+# nginx UI-injection config rendered to the opencode-ui-nginx ConfigMap.
+# The SPA is compiled into the opencode binary, so a patched bundle (fixes per-device
+# home-session visibility) is served from the workspace PVC. Patch source: .ui/README.md.
+uiNginxConf:
+  default.conf: |
+    server {
+      listen 80;
+      location = /assets/index-DkiM3pJJ.js {
+        alias /workspace/.ui/index-DkiM3pJJ.js;
+        default_type application/javascript;
+        add_header Cache-Control "no-cache";
+      }
+      location / {
+        proxy_pass http://127.0.0.1:4096;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+      }
+    }

--- a/charts/vllm/Chart.lock
+++ b/charts/vllm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: app-template
+  repository: https://bjw-s-labs.github.io/helm-charts/
+  version: 3.7.3
+digest: sha256:c519bb3ff6aa1460d0ac8ae623fb9656ffce840536696aa934c390ac1703eb21
+generated: "2026-08-06T22:23:10.997910903Z"

--- a/charts/vllm/Chart.yaml
+++ b/charts/vllm/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: vllm
+description: vLLM inference server
+type: application
+version: 0.1.0
+appVersion: "latest"
+dependencies:
+  - name: app-template
+    version: 3.x.x
+    repository: https://bjw-s-labs.github.io/helm-charts/

--- a/charts/vllm/templates/configmap.yaml
+++ b/charts/vllm/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-config
+  namespace: {{ .Release.Namespace }}
+data:
+  # vLLM serve configuration file: https://docs.vllm.ai/en/stable/configuration/serve_args/
+  config.yaml: |
+{{ range .Values.config }}    {{ .key }}: {{ .value }}
+{{ end }}

--- a/charts/vllm/values.yaml
+++ b/charts/vllm/values.yaml
@@ -1,0 +1,140 @@
+app-template:
+  controllers:
+    vllm:
+      type: deployment
+      replicas: 1
+      strategy: Recreate
+
+      containers:
+        main:
+          image:
+            repository: docker.io/kyuz0/vllm-therock-gfx1151
+            tag: latest
+            pullPolicy: Always
+          command:
+            - /bin/bash
+            - -c
+            - python /root/.cache/huggingface/patch_rocm.py && exec vllm serve --config /vllm/config/config.yaml
+          env:
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: LD_PRELOAD
+              value: /root/.cache/huggingface/hip_mem_override.so
+            - name: PYTORCH_CUDA_ALLOC_CONF
+              value: expandable_segments:True
+            - name: VLLM_DISABLE_COMPILE_CACHE
+              value: "1"
+            - name: VLLM_USE_TRITON_AWQ
+              value: "1"
+            - name: VLLM_ROCM_USE_AITER
+              value: "1"
+            - name: GPU_ARCHS
+              value: native
+            - name: VLLM_TUNED_CONFIG_FOLDER
+              value: /root/.cache/huggingface/moe-tuned
+          probes:
+            readiness:
+              enabled: true
+              custom: true
+              spec:
+                httpGet:
+                  path: /v1/models
+                  port: 8000
+                initialDelaySeconds: 30
+                periodSeconds: 15
+                timeoutSeconds: 5
+                failureThreshold: 6
+          resources:
+            requests:
+              amd.com/gpu: "1"
+            limits:
+              amd.com/gpu: "1"
+
+      pod:
+        # Pin to the node with the GPU (mirrors the original deployment nodeSelector)
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/hostname
+                      operator: In
+                      values:
+                        - framework-desktop
+
+  service:
+    main:
+      controller: vllm
+      type: ClusterIP
+      ports:
+        http:
+          port: 8000
+
+  ingress:
+    main:
+      enabled: true
+      className: tailscale
+      annotations:
+        tailscale.com/proxy-class: "pin-framework-desktop"
+      hosts:
+        - host: vllm
+          paths:
+            - path: /
+              pathType: Prefix
+              service:
+                identifier: main
+                port: http
+      tls:
+        - hosts:
+            - vllm
+
+  persistence:
+    vllm-config:
+      enabled: true
+      type: configMap
+      name: vllm-config
+      globalMounts:
+        - path: /vllm/config
+    hf-cache:
+      enabled: true
+      type: persistentVolumeClaim
+      existingClaim: vllm-hf-cache
+      globalMounts:
+        - path: /root/.cache/huggingface
+
+# -- vLLM serve configuration, rendered to config.yaml and loaded via `vllm serve --config`.
+# Long-form arg names: https://docs.vllm.ai/en/stable/configuration/serve_args/
+# Order is significant: matches the live ConfigMap so a sync is a no-op.
+config:
+  - key: attention-backend
+    value: ROCM_ATTN
+  - key: enable-prefix-caching
+    value: true
+  - key: enable-chunked-prefill
+    value: true
+  - key: dtype
+    value: auto
+  - key: enable-auto-tool-choice
+    value: true
+  - key: gpu-memory-utilization
+    value: 0.8
+  - key: host
+    value: 0.0.0.0
+  - key: max-model-len
+    value: 262144
+  - key: max-num-seqs
+    value: 4
+  - key: mm-encoder-attn-backend
+    value: TRITON_ATTN
+  - key: model
+    value: cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit
+  - key: port
+    value: 8000
+  - key: reasoning-parser
+    value: qwen3
+  - key: tensor-parallel-size
+    value: 1
+  - key: tool-call-parser
+    value: qwen3_xml
+  - key: trust-remote-code
+    value: true


### PR DESCRIPTION
## Summary

Consolidates the previously separate `opencode` and `vllm` branches into one branch (`opencode-vllm`) that both ArgoCD apps now track.

## Changes

- **Branch consolidation**: `origin/vllm` + `origin/opencode` merged into `opencode-vllm`. The opencode-specific work (`apps/ai/opencode*`) is added on top of the reconciled vllm chart.
- **vllm app** (`apps/ai/vllm.yaml`): both Helm sources now target `opencode-vllm`. Autosync remains **disabled** (`enabled: false`).
- **vllm chart** (`charts/vllm`): reconciled to the live deployment so a sync is a no-op — startup command runs `patch_rocm.py`, env list matches live (incl. `VLLM_ROCM_USE_AITER`, `GPU_ARCHS`, `VLLM_TUNED_CONFIG_FOLDER`), and `config.yaml` renders in live order (`ROCM_ATTN`, `max-num-seqs: 4`, prefix-caching/chunked-prefill). Vendored app-template 3.7.3.
- **opencode app** (`apps/ai/opencode.yaml`): now targets `opencode-vllm` and has autosync **disabled** (previously on) to match the vllm pattern.
- **Dropped** `vllm-debug.yaml` (leftover debug manifest, app never created).

## Verification

- Both ArgoCD apps (opencode, vllm) report **Synced/Healthy** at commit `8a906ab`.
- No workloads restarted: `vllm` deployment still revision 11, `opencode`/opencode-router revisions unchanged, pod start times identical.
- `helm template` output of the consolidated branch is byte-identical to the previously verified render matching live.