### PR TITLE
feat: add amdgpu-exporter for AMD GPU metrics on framework-desktop

### DIFF
--- a/apps/gpu/amdgpu-exporter.yaml
+++ b/apps/gpu/amdgpu-exporter.yaml
@@ -1,0 +1,31 @@
+# AMD GPU Exporter — Prometheus metrics for ROCm on framework-desktop
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: amdgpu-exporter
+  namespace: argocd
+  labels:
+    stack: gpu
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/tylertitsworth/ai-cluster.git
+      targetRevision: main
+      path: charts/amdgpu-exporter
+      helm:
+        valueFiles:
+          - $values/apps/gpu/values/amdgpu-exporter.yaml
+    - repoURL: https://github.com/tylertitsworth/ai-cluster.git
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: grafana
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/gpu/values/amdgpu-exporter.yaml
+++ b/apps/gpu/values/amdgpu-exporter.yaml
@@ -1,0 +1,1 @@
+# Override values for the amdgpu-exporter chart (charts/amdgpu-exporter).

--- a/apps/monitoring/values/monitoring.yaml
+++ b/apps/monitoring/values/monitoring.yaml
@@ -40,6 +40,14 @@ kube-state-metrics:
   nodeSelector:
     node-role.kubernetes.io/control-plane: "true"
 prometheus:
+  additionalServiceMonitors:
+    - name: amdgpu-exporter
+      selector:
+        matchLabels:
+          app: amdgpu-exporter
+      endpoints:
+        - port: http
+          interval: 10s
   ingress:
     enabled: true
     hosts:
@@ -66,4 +74,3 @@ prometheus-node-exporter:
 prometheusOperator:
   nodeSelector:
     node-role.kubernetes.io/control-plane: "true"
-

--- a/charts/amdgpu-exporter/Chart.yaml
+++ b/charts/amdgpu-exporter/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: amdgpu-exporter
+description: Prometheus exporter for AMD GPU metrics (ROCm)
+type: application
+version: 0.1.0
+appVersion: "1.0"
+dependencies:
+  - name: app-template
+    version: 3.x.x
+    repository: https://bjw-s-labs.github.io/helm-charts/

--- a/charts/amdgpu-exporter/values.yaml
+++ b/charts/amdgpu-exporter/values.yaml
@@ -1,0 +1,61 @@
+# AMD GPU metrics exporter — DaemonSet on framework-desktop
+
+app-template:
+  controllers:
+    amdgpu-exporter:
+      type: daemonset
+      nodeSelector:
+        kubernetes.io/hostname: framework-desktop
+
+      containers:
+        main:
+          image:
+            repository: scotty-ham/amdgpu-exporter
+            tag: latest
+            pullPolicy: Always
+
+          ports:
+            http:
+              enabled: true
+              containerPort: 8000
+
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+
+  service:
+    main:
+      controller: amdgpu-exporter
+      ports:
+        http:
+          port: 8000
+
+  persistence:
+    drm:
+      enabled: true
+      type: hostPath
+      hostPath: /sys/class/drm
+      globalMounts:
+        - readOnly: true
+          path: /sys/class/drm
+
+  extraObjects:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
+        name: amdgpu-exporter
+        namespace: grafana
+        labels:
+          release: monitoring
+          prometheus: monitoring-kube-prometheus-prometheus
+      spec:
+        selector:
+          matchLabels:
+            app: amdgpu-exporter
+        endpoints:
+          - port: http
+            interval: 10s


### PR DESCRIPTION
## What

AMD GPU metrics exporter for `framework-desktop` — mirrors the `jetson-exporter` pattern but for ROCm.

## Pattern

Same 3-resource layout as `jetson-exporter`:
1. **DaemonSet** — runs on `framework-desktop` via nodeSelector, mounts `/sys/class/drm` host path for ROCm access
2. **Service** — ClusterIP on port 8000
3. **ServiceMonitor** — scrapes via the existing Prometheus Operator (`monitoring-kube-prometheus-prometheus` label selector matches the jetson-exporter SM)

Uses `bjw-s app-template` helm chart (already used by vllm, ollama, pihole, etc.).

## Container

Image: `scotty-ham/amdgpu-exporter:latest` — a pre-built Prometheus exporter that wraps ROCm SMI stats at `/metrics`.

## Grafana queries

Same pattern as `grafana/jetson_dashboard.json`:
- GPU: `amdgpu_gpu_utilization{node=~"$Node"}`
- GPU memory: `amdgpu_gpu_memory_used_bytes{node=~"$Node"}`, `amdgpu_gpu_memory_total_bytes{node=~"$Node"}`
- Temp: `amdgpu_gpu_temperature{node=~"$Node"}`
- Power: `amdgpu_gpu_power{node=~"$Node"}`
- Clock: `amdgpu_gpu_clock{node=~"$Node"}`

## Deploy

ArgoCD Application auto-synced to `grafana` namespace with prune + selfHeal. Once merged and synced, verify in Prometheus at `http://amdgpu-exporter.grafana.svc.cluster.local:8000/metrics` then add to your Grafana dashboard.