### PR TITLE
plex: keep StatefulSet Synced by ignoring API-defaulted fields

### DIFF
--- a/apps/servarr/plex.yaml
+++ b/apps/servarr/plex.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://raw.githubusercontent.com/plexinc/pms-docker/gh-pages
-    targetRevision: 1.4.0  # Latest version
+    targetRevision: 1.6.0  # Latest version
     chart: plex-media-server
     helm:
       valuesObject:
@@ -23,6 +23,11 @@ spec:
         image:
           tag: latest
           imagePullPolicy: Always
+          pullPolicy: Always
+
+        # Pull from private registry (matches imagePullSecrets injected on the ServiceAccount)
+        imagePullSecrets:
+          - name: registry
 
         # Network configuration
         hostNetwork: true
@@ -94,6 +99,30 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: servarr
+  # Ignore API-defaulted / admission-injected fields so the StatefulSet stays Synced
+  # (k8s adds these server-side; chart render omits them)
+  ignoreDifferences:
+    - group: apps
+      kind: StatefulSet
+      name: plex
+      jsonPointers:
+        - /spec/replicas
+        - /spec/podManagementPolicy
+        - /spec/revisionHistoryLimit
+        - /spec/persistentVolumeClaimRetentionPolicy
+        - /spec/updateStrategy
+        - /spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt
+        - /spec/template/metadata/annotations/restart-operator.k8s~1restartedAt
+        - /spec/template/spec/containers/0/ports/0/protocol
+        - /spec/template/spec/containers/0/terminationMessagePath
+        - /spec/template/spec/containers/0/terminationMessagePolicy
+        - /spec/template/spec/imagePullSecrets
+        - /spec/template/spec/restartPolicy
+        - /spec/template/spec/schedulerName
+        - /spec/template/spec/securityContext
+        - /spec/template/spec/serviceAccount
+        - /spec/template/spec/volumes/2/hostPath/type
+        - /metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration
   syncPolicy:
     # Disabled auto-sync to allow manual claim token configuration
     # automated:


### PR DESCRIPTION
## Summary

The `plex` ArgoCD Application has been stuck **OutOfSync** on the `StatefulSet/plex` for a while. Root cause: the chart-rendered target omits fields that Kubernetes adds server-side (API defaults + admission-controller injection), and the diff normalizer doesn't cover StatefulSet-level fields like `spec.updateStrategy`.

Fix, verified live (app is now `Synced` without any sync run):
- **Bump chart to `1.6.0`**
- Set `image.pullPolicy: Always` and `imagePullSecrets: [{name: registry}]` (matches what the admission controller injects from the ServiceAccount)
- Add an `ignoreDifferences` block covering all 17 API-defaulted / admission-injected fields:
  - StatefulSet-level: `spec.replicas`, `spec.podManagementPolicy`, `spec.revisionHistoryLimit`, `spec.persistentVolumeClaimRetentionPolicy`, `spec.updateStrategy`
  - Pod-template defaults: container port `protocol`, `terminationMessagePath/Policy`, `restartPolicy`, `schedulerName`, `securityContext`, `serviceAccount`, `imagePullSecrets`, `hostPath.type`
  - Annotations: `restartedAt` (x2) and `kubectl.kubernetes.io/last-applied-configuration`