### PR TITLE
Fix amdgpu-exporter node label and instance relabeling

### DIFF
--- a/charts/amdgpu-exporter/values.yaml
+++ b/charts/amdgpu-exporter/values.yaml
@@ -13,12 +13,17 @@ app-template:
             repository: python
             tag: 3.12-alpine
             pullPolicy: IfNotPresent
+          env:
+            NODE_NAME:
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           command:
             - sh
             - -c
             - |
               pip install prometheus-client
-              NODE_NAME=$(hostname) python /metrics/amd_exporter.py --port 9494
+              python /metrics/amd_exporter.py --port 9494
           ports:
             - name: http
               containerPort: 9494
@@ -183,3 +188,6 @@ app-template:
       endpoints:
         - port: http
           interval: 10s
+          relabelings:
+            - sourceLabels: [__meta_kubernetes_pod_node_name]
+              targetLabel: instance


### PR DESCRIPTION
Fix amdgpu-exporter node label by using the Kubernetes downward API (`spec.nodeName`) instead of `hostname`, and drop the now-unneeded shell substitution.

Re-opened: the direct push to main that previously contained this fix (`8c20322`) was removed from main history during a token purge, so this fix is no longer on main.