### PR TITLE
Add Airflow 3 dashboard with KubeRay RayJob train workflow

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -1,0 +1,55 @@
+# Airflow (Apache Airflow 3)
+
+Airflow 3 dashboard for the ai-cluster. The API server component serves both
+the web UI and the REST API; it is exposed on the tailnet via a Tailscale
+Ingress: **https://airflow.tail79a5c8.ts.net** (admin / admin).
+
+The DAG in `airflow/dags/ray_train_workflow.py` mirrors the Flyte
+`train_workflow` (`download_dataset -> train_model`) on KubeRay: each task
+submits a `RayJob` CR that boots a throwaway RayCluster
+(`rayproject/ray:2.55.0`) and runs an inline demo script, then waits for the
+job to succeed.
+
+## Why a custom operator instead of a "ray provider"?
+
+There is no Apache Ray provider for Airflow 3 (`apache-airflow-providers-apache-ray`
+does not exist; the legacy `airflow-provider-ray` is archived and Airflow-2-era).
+The DAG therefore talks to KubeRay directly through the in-tree
+`cncf-kubernetes` provider (`KubernetesHook`), which is bundled in the official
+image and falls back to in-cluster config with zero Connection setup.
+
+## How the pieces fit
+
+- ArgoCD Application `apps/ai/airflow.yaml` (stack `ai`) installs the official
+  `airflow` helm chart (1.22.0, Airflow 3.2.2, default CeleryExecutor) and
+  applies `manifests/airflow/rayjob-rbac.yaml` (ClusterRole/Binding so the
+  scheduler + worker service accounts can create/read `rayjobs` in the
+  `kuberay` namespace).
+- DAGs are synced from this repo via git-sync (`dags.gitSync`), subPath
+  `airflow/dags`, pinned to the `add/airflow` branch.
+- RayJobs run in the `kuberay` namespace (KubeRay operator watches all
+  namespaces). Each RayJob uses `shutdownAfterJobFinishes: true`, so its
+  RayCluster is torn down when the job ends.
+- Postgres (metadata DB) and Redis (Celery broker) persist on `longhorn`.
+
+## Deploy / update
+
+From `main`, once this branch has merged (see notes below):
+
+```sh
+kubectl apply -f apps/ai/airflow.yaml
+argocd app sync airflow
+```
+
+ArgoCD sync renders the chart + RBAC and applies everything in the `airflow`
+namespace. DAGs appear in the UI within ~1 minute (git-sync period 5s) and the
+scheduler picks up `ray_train_workflow` automatically.
+
+## Notes / follow-ups after the `add/airflow` branch merges
+
+- Flip `dags.gitSync.branch`/`ref` and the manifests source `targetRevision`
+  in `apps/ai/airflow.yaml` from `add/airflow` to `main`.
+- `config.api.base_url` is hardcoded to the current MagicDNS name; update if
+  the tailnet/ingress host changes.
+- The entrypoint scripts are demos; swap in the real dataset + training code
+  (the operator is generic).

--- a/airflow/dags/ray_train_workflow.py
+++ b/airflow/dags/ray_train_workflow.py
@@ -191,7 +191,7 @@ class RayJobOperator(BaseOperator):
         job_status = "NEW"
         while time.monotonic() < deadline:
             time.sleep(self.poll_interval)
-            status = api.get_namespaced_custom_object_status(
+            status = api.get_namespaced_custom_object(
                 RAY_GROUP, RAY_VERSION, RAY_NAMESPACE, RAY_PLURAL, name
             ).get("status", {})
             job_status = status.get("jobStatus", "NEW")

--- a/airflow/dags/ray_train_workflow.py
+++ b/airflow/dags/ray_train_workflow.py
@@ -176,7 +176,7 @@ class RayJobOperator(BaseOperator):
         if not name:
             raise AirflowException(f"Invalid RayJob name: {self.ray_job_name!r}")
         hook = KubernetesHook(conn_id="kubernetes_default")
-        api = hook.get_conn().CustomObjectsApi()
+        api = client.CustomObjectsApi(hook.get_conn())
         try:
             api.create_namespaced_custom_object(
                 RAY_GROUP, RAY_VERSION, RAY_NAMESPACE, RAY_PLURAL, self._rayjob(name)

--- a/airflow/dags/ray_train_workflow.py
+++ b/airflow/dags/ray_train_workflow.py
@@ -1,0 +1,244 @@
+"""
+Ray train workflow.
+
+Mirrors flyte/train.py (download_dataset -> train_model) on KubeRay: each task
+submits a RayJob CR that boots a throwaway RayCluster (rayproject/ray:2.55.0)
+and runs an inline demo script.
+
+There is no Apache Ray provider for Airflow 3 (the legacy airflow-provider-ray
+is archived and Airflow-2-era), so we talk to KubeRay directly through the
+in-tree cncf-kubernetes provider (KubernetesHook), which falls back to
+in-cluster config with no Connection setup.
+
+To train for real, replace the entrypoint scripts with the actual training
+code; the operator is generic and stays.
+"""
+
+import re
+import time
+from datetime import datetime
+
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+from airflow import DAG
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
+
+RAY_IMAGE = "rayproject/ray:2.55.0"
+RAY_NAMESPACE = "kuberay"
+RAY_GROUP, RAY_VERSION, RAY_PLURAL = "ray.io", "v1", "rayjobs"
+
+# KubeRay runs the RayJob entrypoint via `bash -lc <entrypoint>`.
+DOWNLOAD_DATASET = """\
+cat > /tmp/download_dataset.py <<'PYEOF'
+import ray
+from ray.data import from_items
+
+ray.init()
+N, CLASSES, SHARDS = 10_000, 100, 8
+
+
+@ray.remote
+def make_shard(i):
+    return [{"sample_id": j, "label": j % CLASSES} for j in range(i, N, SHARDS)]
+
+
+rows = [r for f in ray.get([make_shard.remote(i) for i in range(SHARDS)]) for r in f]
+ds = from_items(rows)
+print(f"[download_dataset] samples={ds.count()} classes={len(ds.unique('label'))}")
+print("[download_dataset] done")
+PYEOF
+python /tmp/download_dataset.py
+"""
+
+TRAIN_MODEL = """\
+cat > /tmp/train_model.py <<'PYEOF'
+import ray
+from ray.data import from_items
+
+ray.init()
+N, CLASSES, EPOCHS = 10_000, 100, 5
+ds = from_items([{"sample_id": j, "label": j % CLASSES} for j in range(N)])
+
+
+@ray.remote
+def fit_fold(fold_ds, epochs, seed):
+    import random
+
+    rng = random.Random(seed)
+    loss = 2.0
+    for _ in range(epochs):
+        loss = loss * 0.7 + rng.random() * 0.01  # fake SGD progress
+    return loss
+
+
+folds = ds.repartition(8).split(8)
+futures = [fit_fold.remote(fold, EPOCHS, seed=i) for i, fold in enumerate(folds)]
+losses = ray.get(futures)
+print(f"[train_model] folds={len(losses)} mean_loss={sum(losses)/len(losses):.4f}")
+print("[train_model] done")
+PYEOF
+python /tmp/train_model.py
+"""
+
+_TERMINAL_STATUSES = {"SUCCEEDED", "FAILED", "ABORTED", "STOPPED", "SUBMIT_FAILED", "KUBERAY_UNHEALTHY"}
+
+
+def _sanitize_name(raw: str) -> str:
+    name = re.sub(r"[^a-z0-9.-]+", "-", raw.lower()).strip("-")
+    return name[:63].rstrip(".-")
+
+
+class RayJobOperator(BaseOperator):
+    """Submit a KubeRay RayJob CR and wait until it succeeds."""
+
+    template_fields = ("ray_job_name",)
+
+    def __init__(
+        self,
+        *,
+        ray_job_name: str,
+        entrypoint: str,
+        worker_cpus: int = 1,
+        worker_replicas: int = 2,
+        poll_interval: int = 10,
+        timeout: int = 900,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.ray_job_name = ray_job_name
+        self.entrypoint = entrypoint
+        self.worker_cpus = worker_cpus
+        self.worker_replicas = worker_replicas
+        self.poll_interval = poll_interval
+        self.timeout = timeout
+
+    def _rayjob(self, name: str) -> dict:
+        return {
+            "apiVersion": f"{RAY_GROUP}/{RAY_VERSION}",
+            "kind": "RayJob",
+            "metadata": {"name": name, "namespace": RAY_NAMESPACE},
+            "spec": {
+                "entrypoint": self.entrypoint,
+                "shutdownAfterJobFinishes": True,
+                "rayClusterSpec": {
+                    "headGroupSpec": {
+                        "rayStartParams": {"num-cpus": "0"},
+                        "template": {
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "ray-head",
+                                        "image": RAY_IMAGE,
+                                        "resources": {
+                                            "requests": {"cpu": "1", "memory": "2Gi"},
+                                            "limits": {"memory": "2Gi"},
+                                        },
+                                    }
+                                ]
+                            }
+                        },
+                    },
+                    "workerGroupSpecs": [
+                        {
+                            "groupName": "workers",
+                            "replicas": self.worker_replicas,
+                            "minReplicas": self.worker_replicas,
+                            "maxReplicas": self.worker_replicas,
+                            "rayStartParams": {"num-cpus": str(self.worker_cpus)},
+                            "template": {
+                                "spec": {
+                                    "containers": [
+                                        {
+                                            "name": "ray-worker",
+                                            "image": RAY_IMAGE,
+                                            "resources": {
+                                                "requests": {
+                                                    "cpu": str(self.worker_cpus),
+                                                    "memory": "2Gi",
+                                                },
+                                                "limits": {"memory": "2Gi"},
+                                            },
+                                        }
+                                    ]
+                                }
+                            },
+                        }
+                    ],
+                },
+            },
+        }
+
+    def execute(self, context):
+        name = _sanitize_name(self.ray_job_name)
+        if not name:
+            raise AirflowException(f"Invalid RayJob name: {self.ray_job_name!r}")
+        hook = KubernetesHook(conn_id="kubernetes_default")
+        api = hook.get_conn().CustomObjectsApi()
+        try:
+            api.create_namespaced_custom_object(
+                RAY_GROUP, RAY_VERSION, RAY_NAMESPACE, RAY_PLURAL, self._rayjob(name)
+            )
+            self.log.info("Submitted RayJob %s in namespace %s", name, RAY_NAMESPACE)
+        except ApiException as exc:
+            if exc.status != 409:
+                raise
+            # Already exists from a previous attempt of this task run: resume.
+            self.log.info("RayJob %s already exists, resuming wait", name)
+        deadline = time.monotonic() + self.timeout
+        job_status = "NEW"
+        while time.monotonic() < deadline:
+            time.sleep(self.poll_interval)
+            status = api.get_namespaced_custom_object_status(
+                RAY_GROUP, RAY_VERSION, RAY_NAMESPACE, RAY_PLURAL, name
+            ).get("status", {})
+            job_status = status.get("jobStatus", "NEW")
+            self.log.info("RayJob %s status: %s", name, job_status)
+            if job_status in _TERMINAL_STATUSES:
+                break
+        else:
+            self._cleanup(api, name)
+            raise AirflowException(f"RayJob {name} did not finish within {self.timeout}s")
+        if job_status != "SUCCEEDED":
+            self._cleanup(api, name)
+            raise AirflowException(f"RayJob {name} finished with status {job_status!r}")
+        return job_status
+
+    def _cleanup(self, api, name):
+        try:
+            api.delete_namespaced_custom_object(
+                RAY_GROUP, RAY_VERSION, RAY_NAMESPACE, RAY_PLURAL, name
+            )
+        except Exception as exc:  # best-effort
+            self.log.warning("Failed to delete RayJob %s: %s", name, exc)
+
+
+with DAG(
+    dag_id="ray_train_workflow",
+    schedule=None,
+    start_date=datetime(2026, 8, 13),
+    catchup=False,
+    default_args={"owner": "airflow", "retries": 0},
+    max_active_runs=1,
+    tags=["ray", "demo", "kuberay"],
+) as dag:
+    download_dataset = RayJobOperator(
+        task_id="download_dataset",
+        ray_job_name="download-dataset-{{ run_id }}",
+        entrypoint=DOWNLOAD_DATASET,
+        worker_cpus=1,
+        worker_replicas=2,
+        timeout=900,
+    )
+    train_model = RayJobOperator(
+        task_id="train_model",
+        ray_job_name="train-model-{{ run_id }}",
+        entrypoint=TRAIN_MODEL,
+        worker_cpus=1,
+        worker_replicas=2,
+        timeout=900,
+    )
+
+    download_dataset >> train_model

--- a/apps/ai/airflow.yaml
+++ b/apps/ai/airflow.yaml
@@ -1,0 +1,67 @@
+# Airflow 3 - orchestration dashboard (API server serves the UI + REST API).
+# DAGs sync from this repo via git-sync (airflow/dags on the pinned branch);
+# tasks submit KubeRay RayJob CRs directly (there is no Apache Ray provider
+# for Airflow 3, so the DAG uses the in-tree cncf-kubernetes provider).
+#
+# NOTE: gitSync ref and the manifests source pin branch "add/airflow";
+# flip both to "main" after this branch merges.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: airflow
+  namespace: argocd
+  labels:
+    stack: ai
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://airflow.apache.org
+      chart: airflow
+      targetRevision: 1.22.0
+      helm:
+        valuesObject:
+          # DAGs sync from this repo (airflow/dags).
+          dags:
+            gitSync:
+              enabled: true
+              repo: https://github.com/tylertitsworth/ai-cluster.git
+              branch: add/airflow
+              ref: add/airflow
+              subPath: airflow/dags
+          # Tailscale ingress in front of the apiServer (UI + API).
+          ingress:
+            apiServer:
+              enabled: true
+              ingressClassName: tailscale
+              annotations:
+                tailscale.com/proxy-class: "pin-framework-desktop"
+              hosts:
+                - name: airflow
+                  tls:
+                    enabled: false
+          apiServer:
+            args:
+              - bash
+              - -c
+              - exec airflow api-server --proxy-headers
+          config:
+            api:
+              base_url: https://airflow.tail79a5c8.ts.net
+          # Longhorn-backed metadata DB + broker for the default CeleryExecutor.
+          postgresql:
+            persistence:
+              storageClass: longhorn
+          redis:
+            persistence:
+              storageClassName: longhorn
+    - repoURL: https://github.com/tylertitsworth/ai-cluster.git
+      targetRevision: add/airflow
+      path: manifests/airflow
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: airflow
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/ai/airflow.yaml
+++ b/apps/ai/airflow.yaml
@@ -40,7 +40,7 @@ spec:
               hosts:
                 - name: airflow
                   tls:
-                    enabled: false
+                    enabled: true
           apiServer:
             args:
               - bash
@@ -56,6 +56,20 @@ spec:
           redis:
             persistence:
               storageClassName: longhorn
+          # Worker/triggerer log volumes default to 100Gi; clamp to 10Gi.
+          workers:
+            persistence:
+              size: 10Gi
+          triggerer:
+            persistence:
+              size: 10Gi
+          # The migrate + create-user jobs are Helm-hook-gated by default, which
+          # ArgoCD does not run; render them as plain resources so the DB
+          # migrates and admin/admin is created on sync.
+          migrateDatabaseJob:
+            useHelmHooks: false
+          createUserJob:
+            useHelmHooks: false
     - repoURL: https://github.com/tylertitsworth/ai-cluster.git
       targetRevision: add/airflow
       path: manifests/airflow
@@ -65,3 +79,7 @@ spec:
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
+      # The chart gates fernet-key/redis-password/broker-url as pre-install
+      # hooks; without this ArgoCD never creates them and pods hang on
+      # CreateContainerConfigError.
+      - --enable-helm-hooks

--- a/manifests/airflow/rayjob-rbac.yaml
+++ b/manifests/airflow/rayjob-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   name: airflow-rayjob
 rules:
   - apiGroups: ["ray.io"]
-    resources: ["rayjobs"]
+    resources: ["rayjobs", "rayjobs/status"]
     verbs: ["get", "list", "watch", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/airflow/rayjob-rbac.yaml
+++ b/manifests/airflow/rayjob-rbac.yaml
@@ -1,0 +1,27 @@
+# RBAC for Airflow (release "airflow") to submit KubeRay RayJob CRs and read
+# them back while polling. Bound to the scheduler + worker service accounts
+# the airflow chart creates; the RayJobs live in the "kuberay" namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: airflow-rayjob
+rules:
+  - apiGroups: ["ray.io"]
+    resources: ["rayjobs"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: airflow-rayjob
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: airflow-rayjob
+subjects:
+  - kind: ServiceAccount
+    name: airflow-scheduler
+    namespace: airflow
+  - kind: ServiceAccount
+    name: airflow-worker
+    namespace: airflow


### PR DESCRIPTION
Deploys Airflow 3 (chart 1.22.0, Airflow 3.2.2) on the cluster behind a Tailscale ingress (`airflow.tail79a5c8.ts.net`, admin/admin), and a demo `ray_train_workflow` DAG that mirrors `flyte/train.py` (`download_dataset -> train_model`) on KubeRay.

## Why a custom operator instead of a ray provider
There is no Apache Ray provider for Airflow 3 (`apache-airflow-providers-apache-ray` does not exist; the legacy `airflow-provider-ray` is archived / Airflow-2-era). The DAG talks to KubeRay directly via the in-tree `cncf-kubernetes` provider (`KubernetesHook`), which is bundled in the official image and falls back to in-cluster config with zero Connection setup.

## What's here
- `apps/ai/airflow.yaml` — multi-source ArgoCD app: official `airflow` helm chart 1.22.0 (inline valuesObject) + `manifests/airflow` from this branch. Values:
  - DAGs via git-sync (`airflow/dags`, branch pinned here for validation)
  - Tailscale ingress in front of the Airflow 3 **apiServer** (serves UI + REST API; note `ingress.web` only renders for Airflow <3.0)
  - `apiServer` args with `--proxy-headers`, `config.api.base_url` = MagicDNS URL
  - postgres + redis (Celery broker) persistent on `longhorn`
- `manifests/airflow/rayjob-rbac.yaml` — ClusterRole/Binding so `airflow-scheduler` + `airflow-worker` SAs can create/read `rayjobs` in the `kuberay` namespace
- `airflow/dags/ray_train_workflow.py` — `RayJobOperator` (submits `ray.io/v1` RayJob, polls `.status.jobStatus`, cleans up on failure/timeout) + `download_dataset >> train_model` demo tasks on `rayproject/ray:2.55.0`
- `airflow/README.md` — how it works, deploy steps, follow-ups

## Post-merge follow-ups
- Flip the two `add/airflow` refs (`dags.gitSync` branch/ref + manifests source `targetRevision`) to `main`
- Demo entrypoint scripts; real training replaces them (operator is generic)
- The demo uses CPU only (no GPU requests in the RayCluster spec)

Note: this is a draft — the app is being deployed and the workflow validated against this branch before merging.